### PR TITLE
Compatibility with sass-module-importer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "description": "SASS foundation library.",
   "main": "README.md",
+  "style": "sass/index.scss",
   "repository": {
     "type": "git",
     "url": "git@github.com:buildit/gravy.git"


### PR DESCRIPTION
When using pure `npm` scripts, it is easier to use a `node-sass` importer rather than using Eyeglass. In my setup, I have [`sass-module-importer`](https://www.npmjs.com/package/sass-module-importer). This importer resolves SASS/SCSS files in node modules just by it's name, e.g.:

```
@import '@buildit/gravy'
````

As a result, the import to `typi` which is in your SASS files works too.

The SASS importer defines to pick up the main style sheet via these settings:

> Set a SCSS/Sass/CSS file on the "main" field of their package.json/bower.json
Set a SCSS/Sass/CSS file on the "style" field of their package.json/bower.json
Have a index.css file on the root of their module

I chose to add a `style` field to the `package.json` file and pointed it to the `index.scss`.
